### PR TITLE
Fix nil and divide-by-zero error for apps with less history

### DIFF
--- a/app/views/home/_chart_tile.html.erb
+++ b/app/views/home/_chart_tile.html.erb
@@ -67,8 +67,8 @@
       <% end %>
         <% periods_ago(@period).each do |period_ago| %>
         <div class="<%= column_size %> text-center">
-          <% value = Metric.calculate_value_period_ago(period_ago, @date, @period, @chart_tile, @app_title) %>
-          <% change = (metric_value / value * 100) - 100 %>
+          <% value = Metric.calculate_value_period_ago(period_ago, @date, @period, @chart_tile, @app_title) || 0 %>
+          <% change = value == 0 ? 0 : (metric_value / value * 100) - 100 %>
           <h5><%= pluralize(period_ago, period_word(@period)) %> Ago</h5>
           <% if @chart_tile["display"] == "number" %>
           <h3><%= value %></h3>


### PR DESCRIPTION
I have an app that's less than a year old, and I made these changes to fix divide-by-zero errors when trying to calculate historical change percentages.