### PR TITLE
Use 0 for average if data is missing.

### DIFF
--- a/app/models/metric.rb
+++ b/app/models/metric.rb
@@ -70,8 +70,8 @@ class Metric < ActiveRecord::Base
         current = current.sum(type["column"])
         previous = previous.sum(type["column"])
       else
-        current = current.average(type["column"])
-        previous = previous.average(type["column"])
+        current = current.average(type["column"]) || 0
+        previous = previous.average(type["column"]) || 0
       end
       change = (current.to_f / previous * 100) - 100
       change


### PR DESCRIPTION
I was getting an error "nil can't be coerced into Float" due to the average returning nil for previous values for a brand-new one-time fee app.

This fix just sets the average to 0 so the page loads.  The sum correctly gets set to 0 already for no data so no fix was needed.

Thanks for this great partner metrics dashboard 👍 