### PR TITLE
Revert "Adding link to Baremetrics, now that they support Shopify apps."

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-**NO LONGER MAINTAINED** This repository is no longer maintained.
-
-**ALTERNATIVES**
-
-**PartnerMetrics.io** A free hosted version of Partner Metrics for Shopify is available at [www.partnermetrics.io](https://partnermetrics.io).
-
-**Baremetrics.com** Now supports Shopify Apps - you can link your Shopify Partner payments data and get all kinds of great recurring revenue metrics at [www.baremetrics.com](https://www.baremetrics.com)
+**NO LONGER MAINTAINED** This repository is no longer maintained. I suggest using the hosted version instead ([www.partnermetrics.io](https://partnermetrics.io)), which is still fully supported.
 
 Partner Metrics - for Shopify Partners
 ================


### PR DESCRIPTION
This reverts commit 445326b568b135cf97e34fb4112c6aefb1429a03.

See https://github.com/forsbergplustwo/partner-metrics-for-shopify/commit/445326b568b135cf97e34fb4112c6aefb1429a03#commitcomment-35440629:  
![Screen Shot 2019-10-10 at 12 29 53](https://user-images.githubusercontent.com/2371639/66556888-abe46700-eb59-11e9-96d7-603fefa4d8d3.png)

I asked Scott from Baremetrics to follow up with me when they restart Shopify apps support.

Yesterday I went to this repo, found the link, explored for some time, but was confused after signing up. I think it makes sense to revert the last commit for now. This change may be reverted later 😄 

For the reference:  
- Launch announcement on https://twitter.com/Baremetrics/status/1151935926022606848  
- Help article which is incomplete https://help.baremetrics.com/en/articles/2815413-shopify-partners-apps